### PR TITLE
Updated the folder icon color to match theme color

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -247,7 +247,7 @@ a.external-link:hover:after {
 	opacity: 1;
 }
 .left-sidebar-inner .page-icon {
-	color: #8ec2c2
+	color: var(--ls-active-primary-color);
 }
 /* pre */
 .hljs {

--- a/custom.css
+++ b/custom.css
@@ -246,6 +246,9 @@ a.external-link:hover:after {
 	background-color: rgba(var(--ls-accent-rgb), 0.8);
 	opacity: 1;
 }
+.left-sidebar-inner .page-icon {
+	color: #8ec2c2
+}
 /* pre */
 .hljs {
 	background: transparent;


### PR DESCRIPTION
The new folder icons are using a darker green so I updated the color to match the theme color. This is how it looks like now with the updated CSS.

<img width="223" alt="Screen Shot 2022-06-24 at 11 20 13 AM" src="https://user-images.githubusercontent.com/65195487/175629723-e02b914c-c878-4529-8049-7287cd7c82b9.png">

