### PR TITLE
Fix bullet hover radius

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -560,6 +560,9 @@ html[data-theme="light"] .cm-s-solarized.cm-s-dark .CodeMirror-gutters {
 	transform: translate(1px, -1px);
 	/* align-items: end; */
 }
+.bullet-link-wrap {
+ border-radius:20px; 
+}
 /* Block bullet path in nested block only */
 .ls-block .bullet {
 	background-color: var(--ls-block-bullet-active-color);


### PR DESCRIPTION
Bullet outline became squared when you hover bullet with mouse. This commit makes a simple fix on the bullet wrapper border-radius.